### PR TITLE
Use rtools43 libcurl when available, fixes arm64 builds

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,2 +1,8 @@
-CRT=-ucrt
-include Makevars.win
+# Used on rtools43 and up
+PKG_LIBS = $(shell pkg-config --libs gmpxx mpfr)
+
+# Fallback for older rtools without pkgconfig
+ifeq (,$(PKG_LIBS))
+  CRT=-ucrt
+  include Makevars.win
+endif


### PR DESCRIPTION
Hello! I maintain the libraries on [rwinlib/gmp](https://github.com/rwinlib/gmp) that your package downloads.

For new versions of R, your package should be locating bmp on Windows this new way.

You should try to submit this to CRAN soon; this will fix the build on arm64 on Windows.