### PR TITLE
fix bug in greedy_heuristic_prioritization() feasibility calculations

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: surveyvoi
 Type: Package
-Version: 1.1.0.0
+Version: 1.1.0.1
 Title: Survey Value of Information
 Description: Decision support tool for prioritizing sites for ecological
     surveys based on their potential to improve plans for conserving

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,10 @@
 # surveyvoi 1.1.0.1
 
-- Update `greedy_heuristic_algorithm()` function so that it returns a solution
-  if it is not possible to select enough planning units to meet the target
-  for any species. Instead of throwing an error, it will now throw a warning
-  and return a solution containing the cheapest set of planning units within
-  the budget and locked out constraints. Note that this solution
+- Fix bug in `greedy_heuristic_algorithm()` function so that it returns a
+  solution if it is not possible to select enough planning units to meet the
+  target for any species. Instead of throwing an error, it will now throw a
+  warning and return a solution containing the cheapest set of planning units
+  within the budget and locked out constraints. Note that this solution
   will have an objective value of zero, because it has zero probability of
   meeting any of the species' targets.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+# surveyvoi 1.1.0.1
+
+- Update `greedy_heuristic_algorithm()` function so that it returns a solution
+  if it is not possible to select enough planning units to meet the target
+  for any species. Instead of throwing an error, it will now throw a warning
+  and return a solution containing the cheapest set of planning units within
+  the budget and locked out constraints. Note that this solution
+  will have an objective value of zero, because it has zero probability of
+  meeting any of the species' targets.
+
 # surveyvoi 1.1.0.0
 
 - New `greedy_heuristic_algorithm()` function that can be used to generate

--- a/R/greedy_heuristic_optimization.R
+++ b/R/greedy_heuristic_optimization.R
@@ -142,15 +142,36 @@ greedy_heuristic_prioritization <- function(
     site_management_locked_out <- rep(FALSE, nrow(site_data))
   }
 
-  ## validate that targets are feasible given budget and locked out units
-  sorted_costs <- sort(
-    site_data[[site_management_cost_column]][!site_management_locked_out])
-  sorted_costs <- sorted_costs[
-    seq_len(max(feature_data[[feature_target_column]]))]
-  assertthat::assert_that(
-    sum(sorted_costs) <= total_budget,
-    msg = paste("targets cannot be achieved given budget and locked out",
-                "planning units"))
+  ## validate it is possible to select enough planning units to meet
+  ## the target for even a single feature,
+  ## if not, then it's not possible to generate a single solution
+  ## with an objective value = 0
+  cheapest_sol <- rep(FALSE, nrow(site_data))
+  cheapest_sol[site_management_locked_in] <- TRUE
+  if (min(feature_data[[feature_target_column]]) > sum(cheapest_sol)) {
+    idx <- which(!site_management_locked_out & !site_management_locked_in)
+    idx_costs <- site_data[[site_management_cost_column]]
+    idx_costs <- idx_costs[idx]
+    idx_order <- order(idx_costs)
+    idx_add <- cumsum(idx_costs[idx_order]) <= total_budget
+    sel_idx <- idx[idx_order[which(idx_add)]]
+    cheapest_sol[sel_idx] <- TRUE
+  }
+  if (
+    sum(cheapest_sol) < min(feature_data[[feature_target_column]])
+  ) {
+    ### throw warning
+    warning(
+      paste(
+        "it is not possible to select enough planning units to meet",
+        "any targets for even a single feature",
+        "(given the budget and locked out planning units)"
+      ),
+      call. = TRUE, immediate. = FALSE
+    )
+    ## return solution
+    return(list(x = cheapest_sol, objval = 0))
+  }
 
   # create prior data
   prior_data <-

--- a/docs/404.html
+++ b/docs/404.html
@@ -32,7 +32,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="https://github.com/prioritizr/surveyvoi/index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/articles/index.html
+++ b/docs/articles/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/articles/surveyvoi.html
+++ b/docs/articles/surveyvoi.html
@@ -33,7 +33,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 
@@ -72,7 +72,7 @@
       <h1 data-toc-skip>surveyvoi: Survey Value of Information</h1>
                         <h4 data-toc-skip class="author">Jeffrey O. Hanson</h4>
             
-            <h4 data-toc-skip class="date">2024-07-10</h4>
+            <h4 data-toc-skip class="date">2024-07-24</h4>
       
       <small class="dont-index">Source: <a href="https://github.com/prioritizr/surveyvoi/blob/HEAD/vignettes/surveyvoi.Rmd"><code>vignettes/surveyvoi.Rmd</code></a></small>
       <div class="hidden name"><code>surveyvoi.Rmd</code></div>

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 
@@ -50,6 +50,9 @@
       <small>Source: <a href="https://github.com/prioritizr/surveyvoi/blob/HEAD/NEWS.md"><code>NEWS.md</code></a></small>
     </div>
 
+    <div class="section level2">
+<h2 class="page-header" data-toc-text="1.1.0.1" id="surveyvoi-1101">surveyvoi 1.1.0.1<a class="anchor" aria-label="anchor" href="#surveyvoi-1101"></a></h2>
+<ul><li>Update <code>greedy_heuristic_algorithm()</code> function so that it returns a solution if it is not possible to select enough planning units to meet the target for any species. Instead of throwing an error, it will now throw a warning and return a solution containing the cheapest set of planning units within the budget and locked out constraints. Note that this solution will have an objective value of zero, because it has zero probability of meeting any of the species’ targets.</li></ul></div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="1.1.0.0" id="surveyvoi-1100">surveyvoi 1.1.0.0<a class="anchor" aria-label="anchor" href="#surveyvoi-1100"></a></h2>
 <ul><li>New <code>greedy_heuristic_algorithm()</code> function that can be used to generate reserve selection prioritizations. This function provides access to the internal algorithm used for the reserve selection component of the value of information calculations.</li>

--- a/docs/news/index.html
+++ b/docs/news/index.html
@@ -52,7 +52,7 @@
 
     <div class="section level2">
 <h2 class="page-header" data-toc-text="1.1.0.1" id="surveyvoi-1101">surveyvoi 1.1.0.1<a class="anchor" aria-label="anchor" href="#surveyvoi-1101"></a></h2>
-<ul><li>Update <code>greedy_heuristic_algorithm()</code> function so that it returns a solution if it is not possible to select enough planning units to meet the target for any species. Instead of throwing an error, it will now throw a warning and return a solution containing the cheapest set of planning units within the budget and locked out constraints. Note that this solution will have an objective value of zero, because it has zero probability of meeting any of the species’ targets.</li></ul></div>
+<ul><li>Fix bug in <code>greedy_heuristic_algorithm()</code> function so that it returns a solution if it is not possible to select enough planning units to meet the target for any species. Instead of throwing an error, it will now throw a warning and return a solution containing the cheapest set of planning units within the budget and locked out constraints. Note that this solution will have an objective value of zero, because it has zero probability of meeting any of the species’ targets.</li></ul></div>
     <div class="section level2">
 <h2 class="page-header" data-toc-text="1.1.0.0" id="surveyvoi-1100">surveyvoi 1.1.0.0<a class="anchor" aria-label="anchor" href="#surveyvoi-1100"></a></h2>
 <ul><li>New <code>greedy_heuristic_algorithm()</code> function that can be used to generate reserve selection prioritizations. This function provides access to the internal algorithm used for the reserve selection component of the value of information calculations.</li>

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,7 +3,7 @@ pkgdown: 2.0.7
 pkgdown_sha: ~
 articles:
   surveyvoi: surveyvoi.html
-last_built: 2024-07-09T23:25Z
+last_built: 2024-07-24T01:46Z
 urls:
   reference: https://github.com/prioritizr/surveyvoi/reference
   article: https://github.com/prioritizr/surveyvoi/articles

--- a/docs/pkgdown.yml
+++ b/docs/pkgdown.yml
@@ -3,7 +3,7 @@ pkgdown: 2.0.7
 pkgdown_sha: ~
 articles:
   surveyvoi: surveyvoi.html
-last_built: 2024-07-24T01:46Z
+last_built: 2024-07-24T01:59Z
 urls:
   reference: https://github.com/prioritizr/surveyvoi/reference
   article: https://github.com/prioritizr/surveyvoi/articles

--- a/docs/reference/approx_evdsi.html
+++ b/docs/reference/approx_evdsi.html
@@ -21,7 +21,7 @@ an approximation method is used."><!-- mathjax --><script src="https://cdnjs.clo
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/approx_near_optimal_survey_scheme.html
+++ b/docs/reference/approx_near_optimal_survey_scheme.html
@@ -20,7 +20,7 @@ and a greedy heuristic algorithm to maximize this metric."><!-- mathjax --><scri
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/approx_optimal_survey_scheme.html
+++ b/docs/reference/approx_optimal_survey_scheme.html
@@ -19,7 +19,7 @@ for calculating the expected value of the decision given a survey scheme."><!-- 
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/env_div_survey_scheme.html
+++ b/docs/reference/env_div_survey_scheme.html
@@ -18,7 +18,7 @@ conditions that are surveyed."><!-- mathjax --><script src="https://cdnjs.cloudf
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/evdci.html
+++ b/docs/reference/evdci.html
@@ -20,7 +20,7 @@ existing biodiversity data (i.e. survey data and environmental niche models)."><
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/evdsi.html
+++ b/docs/reference/evdsi.html
@@ -20,7 +20,7 @@ set of sites to help inform the decision."><!-- mathjax --><script src="https://
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/feasible_survey_schemes.html
+++ b/docs/reference/feasible_survey_schemes.html
@@ -18,7 +18,7 @@ survey schemes given survey costs and a fixed budget."><!-- mathjax --><script s
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/fit_hglm_occupancy_models.html
+++ b/docs/reference/fit_hglm_occupancy_models.html
@@ -23,7 +23,7 @@ covariate coefficients are sampled using a Laplace prior distribution
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/fit_xgb_occupancy_models.html
+++ b/docs/reference/fit_xgb_occupancy_models.html
@@ -19,7 +19,7 @@ xgboost::xgb.train())."><!-- mathjax --><script src="https://cdnjs.cloudflare.co
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/geo_cov_survey_scheme.html
+++ b/docs/reference/geo_cov_survey_scheme.html
@@ -18,7 +18,7 @@ of surveys."><!-- mathjax --><script src="https://cdnjs.cloudflare.com/ajax/libs
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/greedy_heuristic_prioritization.html
+++ b/docs/reference/greedy_heuristic_prioritization.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/n_states.html
+++ b/docs/reference/n_states.html
@@ -18,7 +18,7 @@ number of sites and features."><!-- mathjax --><script src="https://cdnjs.cloudf
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/optimal_survey_scheme.html
+++ b/docs/reference/optimal_survey_scheme.html
@@ -19,7 +19,7 @@ calculating the expected value of the decision given a survey scheme."><!-- math
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/prior_probability_matrix.html
+++ b/docs/reference/prior_probability_matrix.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/relative_site_richness_scores.html
+++ b/docs/reference/relative_site_richness_scores.html
@@ -20,7 +20,7 @@ matrices cannot be compared to each other."><!-- mathjax --><script src="https:/
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/relative_site_uncertainty_scores.html
+++ b/docs/reference/relative_site_uncertainty_scores.html
@@ -21,7 +21,7 @@ compared to each other."><!-- mathjax --><script src="https://cdnjs.cloudflare.c
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/sim_data.html
+++ b/docs/reference/sim_data.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/simulate_feature_data.html
+++ b/docs/reference/simulate_feature_data.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/simulate_site_data.html
+++ b/docs/reference/simulate_site_data.html
@@ -17,7 +17,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/surveyvoi.html
+++ b/docs/reference/surveyvoi.html
@@ -28,7 +28,7 @@ value of information analysis."><!-- mathjax --><script src="https://cdnjs.cloud
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/docs/reference/weighted_survey_scheme.html
+++ b/docs/reference/weighted_survey_scheme.html
@@ -18,7 +18,7 @@ overall weight value, a maximum budget for the survey scheme."><!-- mathjax --><
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">surveyvoi</a>
-        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.0</span>
+        <span class="version label label-default" data-toggle="tooltip" data-placement="bottom" title="">1.1.0.1</span>
       </span>
     </div>
 

--- a/inst/doc/surveyvoi.html
+++ b/inst/doc/surveyvoi.html
@@ -12,7 +12,7 @@
 
 <meta name="author" content="Jeffrey O. Hanson" />
 
-<meta name="date" content="2024-07-10" />
+<meta name="date" content="2024-07-24" />
 
 <title>surveyvoi: Survey Value of Information</title>
 
@@ -171,7 +171,7 @@ div.csl-indent {
 
 <h1 class="title toc-ignore">surveyvoi: Survey Value of Information</h1>
 <h4 class="author">Jeffrey O. Hanson</h4>
-<h4 class="date">2024-07-10</h4>
+<h4 class="date">2024-07-24</h4>
 
 
 <div id="TOC">


### PR DESCRIPTION
Fix bug in `greedy_heuristic_algorithm()` function so that it returns a solution if it is not possible to select enough planning units to meet the target for any species. Instead of throwing an error, it will now throw a warning and return a solution containing the cheapest set of planning units within the budget and locked out constraints. Note that this solution will have an objective value of zero, because it has zero probability of meeting any of the species' targets.